### PR TITLE
Modified Makefile destroy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ cluster:
 	k3d create cluster --workers 4 --name gitops
 
 destroy:
-	k3d delete cluster gitops
+	k3d delete --name="gitops"
 
 install-flux:
 	./scripts/flux-init.sh


### PR DESCRIPTION
While running the destroy command from make, it failed with an error.

```
make destroy
k3d delete cluster gitops
FATA[0000] No cluster(s) found
make: *** [destroy] Error 1
```

It appears that the issue is resolved by running this command instead:

```
k3d delete --name="gitops"
```